### PR TITLE
[RCM-25] frontend/lib/server に relayer-wallet.ts を移植

### DIFF
--- a/frontend/lib/server/relayer-wallet.ts
+++ b/frontend/lib/server/relayer-wallet.ts
@@ -1,0 +1,9 @@
+import { ethers } from "ethers";
+
+export const getRelayerWallet = () => {
+	const privateKey = process.env.RELAYER_PRIVATE_KEY;
+	if (!privateKey) {
+		throw new Error("RELAYER_PRIVATE_KEY is not set in environment variables");
+	}
+	return new ethers.Wallet(privateKey);
+};


### PR DESCRIPTION
### Motivation
- Next.js Route Handlers への移植準備として、`backend/src/utils/ethers.ts` の `getRelayerWallet` 相当をフロントエンド側のサーバーディレクトリへ移し、`process.env.RELAYER_PRIVATE_KEY` を参照する既存の動作を維持するため。 

### Description
- 新規ファイル `frontend/lib/server/relayer-wallet.ts` を追加し、`process.env.RELAYER_PRIVATE_KEY` を読み `ethers.Wallet` を返す `getRelayerWallet` を実装しました（未設定時は同等のエラーを投げます）。

### Testing
- 自動化テストとして `cd frontend && npm run lint` を実行しましたが、環境で `next` コマンドが見つからないため `next: not found` エラーで失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f217be6630832fa980535acb6b7c49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リレイヤーウォレット機能を追加しました。環境変数から認証情報を読み込み、安全に管理できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->