### PR TITLE
frontend: signature-service を frontend/lib/server に移植

### DIFF
--- a/frontend/lib/server/signature-service.ts
+++ b/frontend/lib/server/signature-service.ts
@@ -1,0 +1,169 @@
+import { ethers } from "ethers";
+import gaslessERC721A_59141 from "../../../contract/ignition/deployments/chain-59141/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import lineaSepoliaContractAddresses from "../../../contract/ignition/deployments/chain-59141/deployed_addresses.json";
+import gaslessERC721A_80002 from "../../../contract/ignition/deployments/chain-80002/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import amoyContractAddresses from "../../../contract/ignition/deployments/chain-80002/deployed_addresses.json";
+import gaslessERC721A_84532 from "../../../contract/ignition/deployments/chain-84532/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import baseSepoliaContractAddresses from "../../../contract/ignition/deployments/chain-84532/deployed_addresses.json";
+import gaslessERC721A_421614 from "../../../contract/ignition/deployments/chain-421614/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import arbitrumSepoliaContractAddresses from "../../../contract/ignition/deployments/chain-421614/deployed_addresses.json";
+import gaslessERC721A_11155111 from "../../../contract/ignition/deployments/chain-11155111/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import sepoliaContractAddresses from "../../../contract/ignition/deployments/chain-11155111/deployed_addresses.json";
+import gaslessERC721A_11155420 from "../../../contract/ignition/deployments/chain-11155420/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import optimismSepoliaContractAddresses from "../../../contract/ignition/deployments/chain-11155420/deployed_addresses.json";
+import gaslessERC721A_168587773 from "../../../contract/ignition/deployments/chain-168587773/artifacts/GaslessERC721AModule#GaslessERC721A.json";
+import blastSepoliaContractAddresses from "../../../contract/ignition/deployments/chain-168587773/deployed_addresses.json";
+import { getRelayerWallet } from "./relayer-wallet";
+
+// biome-ignore lint/suspicious/noExplicitAny: backend 側の型を維持
+export const gaslessERC721AbiMap: { [key: string]: any } = {
+	"11155111": {
+		abi: gaslessERC721A_11155111.abi,
+		address: sepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://11155111.rpc.thirdweb.com",
+	},
+	"80002": {
+		abi: gaslessERC721A_80002.abi,
+		address: amoyContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://80002.rpc.thirdweb.com",
+	},
+	"11155420": {
+		abi: gaslessERC721A_11155420.abi,
+		address:
+			optimismSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://sepolia.optimism.io",
+	},
+	"421614": {
+		abi: gaslessERC721A_421614.abi,
+		address:
+			arbitrumSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://sepolia-rollup.arbitrum.io/rpc",
+	},
+	"84532": {
+		abi: gaslessERC721A_84532.abi,
+		address: baseSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://sepolia.base.org",
+	},
+	"168587773": {
+		abi: gaslessERC721A_168587773.abi,
+		address:
+			blastSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://sepolia.blast.io",
+	},
+	"59141": {
+		abi: gaslessERC721A_59141.abi,
+		address: lineaSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		rpcUrl: "https://rpc.sepolia.linea.build",
+	},
+};
+
+export function isSupportedNetwork(networkId: string): boolean {
+	return networkId in gaslessERC721AbiMap;
+}
+
+export const getMintParams = async (
+	signer: string,
+	quantity: number,
+	networkId: string,
+) => {
+	if (!isSupportedNetwork(networkId)) {
+		throw new Error(`Unsupported network: ${networkId}`);
+	}
+
+	const networkConfig = gaslessERC721AbiMap[networkId];
+	if (!networkConfig || !networkConfig.address) {
+		throw new Error(`Contract address not found for network: ${networkId}`);
+	}
+
+	const relayerWallet = getRelayerWallet();
+	const provider = new ethers.JsonRpcProvider(networkConfig.rpcUrl);
+	const contract = new ethers.Contract(
+		networkConfig.address,
+		networkConfig.abi,
+		provider,
+	);
+
+	const nonce = await contract.getNonce(signer);
+	const expiry = Math.floor(Date.now() / 1000) + 3600;
+
+	const messageToSign = ethers.solidityPackedKeccak256(
+		["address", "address", "uint256", "uint256", "uint256", "address"],
+		[
+			relayerWallet.address,
+			signer,
+			quantity,
+			nonce,
+			expiry,
+			networkConfig.address,
+		],
+	);
+
+	return {
+		nonce: nonce.toString(),
+		expiry,
+		messageToSign: ethers.hexlify(messageToSign),
+	};
+};
+
+export const verifyAndMint = async (
+	signer: string,
+	quantity: number,
+	nonce: string,
+	expiry: number,
+	signature: string,
+	networkId: string,
+) => {
+	if (!isSupportedNetwork(networkId)) {
+		throw new Error(`Unsupported network: ${networkId}`);
+	}
+
+	const relayerWallet = getRelayerWallet();
+	const provider = new ethers.JsonRpcProvider(
+		gaslessERC721AbiMap[networkId].rpcUrl,
+	);
+	const connectedRelayerWallet = relayerWallet.connect(provider);
+	const abi = gaslessERC721AbiMap[networkId].abi;
+	const contractAddress = gaslessERC721AbiMap[networkId].address;
+	const contract = new ethers.Contract(
+		contractAddress,
+		abi,
+		connectedRelayerWallet,
+	);
+
+	const messageHash = ethers.solidityPackedKeccak256(
+		["address", "address", "uint256", "uint256", "uint256", "address"],
+		[
+			relayerWallet.address,
+			signer,
+			quantity,
+			BigInt(nonce),
+			expiry,
+			contractAddress,
+		],
+	);
+
+	const recoveredAddress = ethers.verifyMessage(
+		ethers.getBytes(messageHash),
+		signature,
+	);
+
+	if (recoveredAddress.toLowerCase() !== signer.toLowerCase()) {
+		throw new Error(
+			`Invalid signature. Expected: ${signer}, Got: ${recoveredAddress}`,
+		);
+	}
+
+	const tx = await contract.gaslessMint(
+		signer,
+		quantity,
+		BigInt(nonce),
+		expiry,
+		signature,
+	);
+	const receipt = await tx.wait();
+
+	return {
+		transactionHash: receipt.hash,
+		blockNumber: receipt.blockNumber.toString(),
+	};
+};


### PR DESCRIPTION
### Motivation
- Next.js Route Handlers に移植する作業の一環として、`backend/src/services/signatureService.ts` の純粋ロジックをフロントエンド側の server ライブラリに移し、API ハンドラから再利用できるようにするため。 

### Description
- 新規ファイル `frontend/lib/server/signature-service.ts` を追加し、`gaslessERC721AbiMap` / `isSupportedNetwork` / `getMintParams` / `verifyAndMint` のロジックを移植しました。 
- コントラクト参照の `import` パスを frontend ルート基準へ相対調整しています（`contract/ignition/deployments/...`）。
- リレイヤーウォレットの取得は既存の `frontend/lib/server/relayer-wallet.ts` を参照するように変更しました（`getRelayerWallet` を利用）。
- backend 側の型互換性を保つために lint コメントと汎用型 `{ [key: string]: any }` を維持しています。 

### Testing
- `cd frontend && npx tsc --noEmit` を実行して型チェックを試行しましたが、プロジェクト全体の依存解決・型定義不足により多数の型エラーが発生して失敗しました。 
- 上記の型エラーは既存のフロントエンド依存に起因するもので、今回追加した `signature-service.ts` 単独が直接の原因ではないと判断しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21b70dcfc832fb929895bdadf2fb3)