### PR TITLE
POST /api/get-mint-params の Route Handler を追加

### DIFF
--- a/frontend/app/api/get-mint-params/route.ts
+++ b/frontend/app/api/get-mint-params/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getMintParams } from "@/lib/server/signature-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+	const { address, quantity, networkId } = await request.json();
+
+	try {
+		const mintParams = await getMintParams(address, quantity, networkId);
+		return NextResponse.json({
+			...mintParams,
+			nonce: mintParams.nonce.toString(),
+		});
+	} catch (error) {
+		console.error("Failed to get mint parameters:", error);
+		return NextResponse.json(
+			{
+				error: "Failed to get mint parameters",
+				message: error instanceof Error ? error.message : String(error),
+			},
+			{ status: 500 },
+		);
+	}
+}


### PR DESCRIPTION
### Motivation
- `backend` のコントローラ実装を Next.js Route Handlers に移植して `/api/get-mint-params` を Next 上で動作させるためにルートハンドラを追加しました。

### Description
- `frontend/app/api/get-mint-params/route.ts` を新規作成し `POST` ハンドラを実装しました。
- `export const runtime = "nodejs"` と `export const dynamic = "force-dynamic"` を設定しました。
- `@/lib/server/signature-service` の `getMintParams` を呼び出し、成功時は `nonce` を文字列化して返却し、失敗時は `error` と `message` を含む 500 JSON を返すようにしました。

### Testing
- フロントエンドで `bun run lint` を実行しましたが、環境に `next` バイナリがないため失敗しました（依存未インストールのため）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21d9e5030832f971fd27babcea7ab)