### PR TITLE
POST /api/mint Route Handler を追加（maxDuration=30）

### DIFF
--- a/frontend/app/api/mint/route.ts
+++ b/frontend/app/api/mint/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { verifyAndMint } from "@/lib/server/signature-service";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function POST(request: Request) {
+	const { address, quantity, nonce, expiry, signature, networkId } =
+		await request.json();
+
+	try {
+		const result = await verifyAndMint(
+			address,
+			quantity,
+			nonce,
+			expiry,
+			signature,
+			networkId,
+		);
+
+		return NextResponse.json(result);
+	} catch (error) {
+		console.error("Failed to mint:", error);
+		return NextResponse.json(
+			{
+				error: "Failed to mint",
+				message: error instanceof Error ? error.message : String(error),
+			},
+			{ status: 500 },
+		);
+	}
+}


### PR DESCRIPTION
### Motivation
- Next.js Route Handlers 化の一環としてバックエンドの `/api/mint` エンドポイントを移植・実装するため。 
- クライアントから署名済みデータを受け取りリレイヤー経由でミント処理を行うためのサーバー側エントリが必要なため。

### Description
- 新規ファイル `frontend/app/api/mint/route.ts` を追加し、`POST` ハンドラを実装した。 
- リクエストボディから `address`, `quantity`, `nonce`, `expiry`, `signature`, `networkId` を受け取り、`verifyAndMint` を呼び出すようにした。 
- `runtime = "nodejs"`, `dynamic = "force-dynamic"` を設定し、`export const maxDuration = 30;` を追加した。 
- 処理結果を JSON で返却し、例外発生時は HTTP 500 とエラーメッセージを返すハンドリングを追加した。 

### Testing
- プロジェクト内で `bun run lint` を実行したが、実行環境で `next` コマンドが見つからずリンターは失敗した（環境依存のためローカル環境での実行を推奨）。
- 他の自動テストは実行しておらず、型チェックや実際のエンドポイント疎通はローカルでのサーバー起動時に確認してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21ec8eb8c832f9c6828a7a4ca9ee6)