### PR TITLE
RCM-29: frontend の ethers を backend と同一バージョンへ更新

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@web3modal/ethers": "^4.2.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "ethers": "^6.12.1",
+    "ethers": "^6.13.2",
     "framer-motion": "^11.5.4",
     "lucide-react": "^0.378.0",
     "next": "14.2.3",


### PR DESCRIPTION
### Motivation
- `frontend/package.json` の `ethers` を `backend/package.json` と同じ `^6.13.2` に合わせ、サーバー/クライアントで同一系統のライブラリを利用するため。 

### Description
- `frontend/package.json` の `ethers` を `^6.12.1` から `^6.13.2` に変更し、該当ファイルをコミットしました。 

### Testing
- `node -e "const f=require('./frontend/package.json'); const b=require('./backend/package.json'); console.log('frontend',f.dependencies.ethers,'backend',b.dependencies.ethers)"` を実行して両方が `^6.13.2` であることを確認し成功しました。 
- `git commit -m "chore: frontendのethersバージョンをbackendに合わせる"` が正常に実行されコミットが作成されました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22018de04832f826d8f171bcd8fab)