### PR TITLE
RCM-31 mint-button.tsx の fetch を相対パスに書き換え

### DIFF
--- a/frontend/app/gasless-mint/[networkUrl]/components/mint-button.tsx
+++ b/frontend/app/gasless-mint/[networkUrl]/components/mint-button.tsx
@@ -110,8 +110,7 @@ export default function MintButton({
         throw new Error('Not enough mints available');
       }
 
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-      const response = await fetch(`${apiUrl}/get-mint-params`, {
+      const response = await fetch('/api/get-mint-params', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -132,7 +131,7 @@ export default function MintButton({
 
       const signature = await signer.signMessage(ethers.getBytes(messageToSign));
 
-      const mintResponse = await fetch(`${apiUrl}/mint`, {
+      const mintResponse = await fetch('/api/mint', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
### Motivation
- Vercel 同一オリジン前提に合わせて、`NEXT_PUBLIC_API_URL` ベースの絶対 URL による API 呼び出しを廃止し、フロントエンドからの API 呼び出しを相対パスに統一するため。 

### Description
- `frontend/app/gasless-mint/[networkUrl]/components/mint-button.tsx` 内で `apiUrl` 解決ロジックを削除し、`fetch('/api/get-mint-params', ...)` と `fetch('/api/mint', ...)` に置換しました。 

### Testing
- `git diff` と `rg -n "NEXT_PUBLIC_API_URL|/api/get-mint-params|/api/mint"` による差分確認で対象の 2 箇所が相対パスに置換されていることを確認し、変更をコミット（`refactor: mint-button fetchを相対パスに変更`）しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d7f9e34832faacf2bf48549cbbb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ミント機能の内部通信プロセスを最適化しました。機能と利用体験に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->