### PR TITLE
Remove Elastic Beanstalk config

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,6 +1,0 @@
-branch-defaults:
-  default:
-    environment: nft-minting-app-backend-env
-global:
-  application_name: nft-minting-app-backend
-  default_region: ap-northeast-1


### PR DESCRIPTION
## Summary

- Removes `.elasticbeanstalk/config.yml`, the legacy AWS Elastic Beanstalk environment configuration.

## Verification

- `git diff --check`
- Confirmed the only tracked `.elasticbeanstalk` file is removed by this PR.
- Confirmed no EB environment config values remain outside migration planning docs.

Linear: RCM-53