### PR TITLE
Update frontend URL helper for Vercel

### DIFF
--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -5,10 +5,14 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
-export const getURL = () => {
-	const url = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+const withProtocol = (url: string) =>
+	url.startsWith("http://") || url.startsWith("https://")
+		? url
+		: `https://${url}`;
 
-	return url
-		? `https://${url}`
-		: `http://localhost:${process.env.PORT || 3000}`;
+export const getURL = () => {
+	const url =
+		process.env.VERCEL_PROJECT_PRODUCTION_URL || process.env.VERCEL_URL;
+
+	return url ? withProtocol(url) : `http://localhost:${process.env.PORT || 3000}`;
 };


### PR DESCRIPTION
## Summary

- Keeps `getURL()` because it is used by `app/layout.tsx` for `metadataBase`.
- Updates `getURL()` to prefer `VERCEL_PROJECT_PRODUCTION_URL` and fall back to `VERCEL_URL` for Vercel preview/deployment URLs.
- Normalizes Vercel hostnames by adding `https://` only when no protocol is present.

## Verification

- `git diff --check`
- `cd frontend && bun run build`

Note: Next.js still reports the existing ESLint-not-installed warning during build, but the build exits successfully.

Linear: RCM-59