### PR TITLE
RCM-86 signature-service のユニットテストを追加

### DIFF
--- a/apps/web/lib/server/signature-service.ts
+++ b/apps/web/lib/server/signature-service.ts
@@ -15,7 +15,6 @@ import gaslessERC721A_168587773 from "../../../../contract/ignition/deployments/
 import blastSepoliaContractAddresses from "../../../../contract/ignition/deployments/chain-168587773/deployed_addresses.json";
 import { getRelayerWallet } from "./relayer-wallet";
 
-// biome-ignore lint/suspicious/noExplicitAny: backend 側の型を維持
 export const gaslessERC721AbiMap: { [key: string]: any } = {
 	"11155111": {
 		abi: gaslessERC721A_11155111.abi,
@@ -41,7 +40,8 @@ export const gaslessERC721AbiMap: { [key: string]: any } = {
 	},
 	"84532": {
 		abi: gaslessERC721A_84532.abi,
-		address: baseSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		address:
+			baseSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
 		rpcUrl: "https://sepolia.base.org",
 	},
 	"168587773": {
@@ -52,7 +52,8 @@ export const gaslessERC721AbiMap: { [key: string]: any } = {
 	},
 	"59141": {
 		abi: gaslessERC721A_59141.abi,
-		address: lineaSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
+		address:
+			lineaSepoliaContractAddresses["GaslessERC721AModule#GaslessERC721A"],
 		rpcUrl: "https://rpc.sepolia.linea.build",
 	},
 };
@@ -61,11 +62,23 @@ export function isSupportedNetwork(networkId: string): boolean {
 	return networkId in gaslessERC721AbiMap;
 }
 
+function validateMintInput(signer: string, quantity: number) {
+	if (!ethers.isAddress(signer)) {
+		throw new Error(`Invalid signer address: ${signer}`);
+	}
+
+	if (!Number.isInteger(quantity) || quantity <= 0) {
+		throw new Error(`Invalid quantity: ${quantity}`);
+	}
+}
+
 export const getMintParams = async (
 	signer: string,
 	quantity: number,
 	networkId: string,
 ) => {
+	validateMintInput(signer, quantity);
+
 	if (!isSupportedNetwork(networkId)) {
 		throw new Error(`Unsupported network: ${networkId}`);
 	}
@@ -113,6 +126,8 @@ export const verifyAndMint = async (
 	signature: string,
 	networkId: string,
 ) => {
+	validateMintInput(signer, quantity);
+
 	if (!isSupportedNetwork(networkId)) {
 		throw new Error(`Unsupported network: ${networkId}`);
 	}

--- a/apps/web/test/signature-service.test.ts
+++ b/apps/web/test/signature-service.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	contract: {
+		getNonce: vi.fn(),
+		gaslessMint: vi.fn(),
+	},
+	JsonRpcProvider: vi.fn(),
+	Contract: vi.fn(),
+	Wallet: vi.fn(),
+	solidityPackedKeccak256: vi.fn(),
+	hexlify: vi.fn(),
+	getBytes: vi.fn(),
+	verifyMessage: vi.fn(),
+	isAddress: vi.fn(),
+}));
+
+vi.mock("ethers", () => ({
+	ethers: {
+		JsonRpcProvider: mocks.JsonRpcProvider,
+		Contract: mocks.Contract,
+		Wallet: mocks.Wallet,
+		solidityPackedKeccak256: mocks.solidityPackedKeccak256,
+		hexlify: mocks.hexlify,
+		getBytes: mocks.getBytes,
+		verifyMessage: mocks.verifyMessage,
+		isAddress: mocks.isAddress,
+	},
+}));
+
+describe("signature-service", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		vi.setSystemTime(new Date("2026-05-02T00:00:00.000Z"));
+		process.env.RELAYER_PRIVATE_KEY = "0xrelayer-private-key";
+
+		mocks.contract.getNonce.mockResolvedValue(42n);
+		mocks.contract.gaslessMint.mockResolvedValue({
+			wait: vi.fn().mockResolvedValue({
+				hash: "0xtx",
+				blockNumber: 12345n,
+			}),
+		});
+		mocks.JsonRpcProvider.mockImplementation(function (rpcUrl: string) {
+			return { rpcUrl };
+		});
+		mocks.Contract.mockImplementation(function () {
+			return mocks.contract;
+		});
+		mocks.Wallet.mockImplementation(function () {
+			return {
+				address: "0xRelayer000000000000000000000000000000000001",
+				connect: vi.fn().mockReturnValue({
+					address: "0xRelayer000000000000000000000000000000000001",
+				}),
+			};
+		});
+		mocks.solidityPackedKeccak256.mockReturnValue("0xmessagehash");
+		mocks.hexlify.mockImplementation((value: string) => value);
+		mocks.getBytes.mockImplementation((value: string) => `bytes:${value}`);
+		mocks.verifyMessage.mockReturnValue(
+			"0x1111111111111111111111111111111111111111",
+		);
+		mocks.isAddress.mockImplementation(
+			(value: string) => value.startsWith("0x") && value.length === 42,
+		);
+	});
+
+	it("サポート対象ネットワークのmintパラメータを生成する", async () => {
+		const { getMintParams } = await import("@/lib/server/signature-service");
+
+		const result = await getMintParams(
+			"0x1111111111111111111111111111111111111111",
+			2,
+			"11155111",
+		);
+
+		expect(result).toEqual({
+			nonce: "42",
+			expiry: 1777683600,
+			messageToSign: "0xmessagehash",
+		});
+		expect(mocks.contract.getNonce).toHaveBeenCalledWith(
+			"0x1111111111111111111111111111111111111111",
+		);
+		expect(mocks.solidityPackedKeccak256).toHaveBeenCalledWith(
+			["address", "address", "uint256", "uint256", "uint256", "address"],
+			[
+				"0xRelayer000000000000000000000000000000000001",
+				"0x1111111111111111111111111111111111111111",
+				2,
+				42n,
+				1777683600,
+				expect.any(String),
+			],
+		);
+	});
+
+	it("未対応ネットワークではmintパラメータを生成しない", async () => {
+		const { getMintParams } = await import("@/lib/server/signature-service");
+
+		await expect(
+			getMintParams("0x1111111111111111111111111111111111111111", 1, "999"),
+		).rejects.toThrow("Unsupported network: 999");
+		expect(mocks.Contract).not.toHaveBeenCalled();
+	});
+
+	it("不正なquantityではmintパラメータを生成しない", async () => {
+		const { getMintParams } = await import("@/lib/server/signature-service");
+
+		await expect(
+			getMintParams(
+				"0x1111111111111111111111111111111111111111",
+				0,
+				"11155111",
+			),
+		).rejects.toThrow("Invalid quantity");
+		expect(mocks.Contract).not.toHaveBeenCalled();
+	});
+
+	it("不正な署名者アドレスではmintパラメータを生成しない", async () => {
+		const { getMintParams } = await import("@/lib/server/signature-service");
+
+		await expect(
+			getMintParams("not-an-address", 1, "11155111"),
+		).rejects.toThrow("Invalid signer address");
+		expect(mocks.Contract).not.toHaveBeenCalled();
+	});
+
+	it("署名者と復元アドレスが一致すればmintを実行する", async () => {
+		const { verifyAndMint } = await import("@/lib/server/signature-service");
+
+		const result = await verifyAndMint(
+			"0x1111111111111111111111111111111111111111",
+			1,
+			"42",
+			1777683600,
+			"0xsignature",
+			"11155111",
+		);
+
+		expect(result).toEqual({
+			transactionHash: "0xtx",
+			blockNumber: "12345",
+		});
+		expect(mocks.contract.gaslessMint).toHaveBeenCalledWith(
+			"0x1111111111111111111111111111111111111111",
+			1,
+			42n,
+			1777683600,
+			"0xsignature",
+		);
+	});
+
+	it("署名者と復元アドレスが一致しなければmintしない", async () => {
+		mocks.verifyMessage.mockReturnValue(
+			"0x2222222222222222222222222222222222222222",
+		);
+		const { verifyAndMint } = await import("@/lib/server/signature-service");
+
+		await expect(
+			verifyAndMint(
+				"0x1111111111111111111111111111111111111111",
+				1,
+				"42",
+				1777683600,
+				"0xsignature",
+				"11155111",
+			),
+		).rejects.toThrow("Invalid signature");
+		expect(mocks.contract.gaslessMint).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,7 +1,38 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	plugins: [
+		{
+			name: "hardhat-artifact-json",
+			enforce: "pre",
+			resolveId(source, importer) {
+				if (
+					!importer ||
+					!source.includes("Module#") ||
+					!source.endsWith(".json")
+				) {
+					return null;
+				}
+
+				return `\0hardhat-artifact-json:${Buffer.from(
+					path.resolve(path.dirname(importer), source),
+				).toString("base64url")}`;
+			},
+			load(id) {
+				if (!id.startsWith("\0hardhat-artifact-json:")) {
+					return null;
+				}
+
+				const filePath = Buffer.from(
+					id.replace("\0hardhat-artifact-json:", ""),
+					"base64url",
+				).toString("utf8");
+				return `export default ${readFileSync(filePath, "utf8")};`;
+			},
+		},
+	],
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname),


### PR DESCRIPTION
## 概要
- `signature-service` のユニットテストを追加
- `getMintParams` の正常系、未対応ネットワーク、不正quantity、不正アドレスを検証
- `verifyAndMint` の署名一致時のmint実行、署名不一致時にmintしないことを検証
- 外部RPCへ接続しないよう `ethers` をモック
- Vitestで `#` を含むHardhat artifact JSONを読めるよう専用resolverを追加
- `signer` と `quantity` の入力検証を `signature-service` に追加

## 検証
- `cd apps/web && bunx biome check lib/server/signature-service.ts test/signature-service.test.ts vitest.config.ts`
- `cd apps/web && bun run test`
- `cd apps/web && bun run build`

Linear: RCM-86